### PR TITLE
chore: add dependabot config for cargo dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: main
+    labels: [auto-dependencies]
+    groups:
+      parquet-variant:
+        applies-to: version-updates
+        patterns:
+          - "parquet-variant*"


### PR DESCRIPTION
Add Dependabot configuration to automatically track Cargo dependency updates.

- Weekly schedule
- `parquet-variant*` crates grouped together (always updated as a set)
- PRs labeled with `auto-dependencies`